### PR TITLE
feat: add image crop before upload in post creation flow

### DIFF
--- a/src/components/AsciiNewPostForm.tsx
+++ b/src/components/AsciiNewPostForm.tsx
@@ -2,9 +2,11 @@ import { useState, useRef } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { useToast } from "@/hooks/use-toast";
+import { useImageCropper } from "@/hooks/useImageCropper";
 import { X, Plus, Image, Film, Loader2, Music, Smile, ChevronDown, ChevronUp, Send } from "lucide-react";
 import MusicEmbed from "./MusicEmbed";
 import GifPicker from "./GifPicker";
+import ImageCropperModal from "./ImageCropperModal";
 
 export type NewPost = {
   title: string;
@@ -29,11 +31,28 @@ export default function AsciiNewPostForm({ onAdd, onClose }: { onAdd: (p: NewPos
   const [mediaExpanded, setMediaExpanded] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const musicInputRef = useRef<HTMLInputElement>(null);
+  const { cropperImage, isCropping, remainingCount, processFiles, advanceQueue, cancelCrop } = useImageCropper();
 
   const addMusic = (url: string) => {
     if (!url.trim()) return;
     setMediaFiles(prev => [...prev, { url, type: 'music' }]);
     setShowMusicInput(false);
+    setMediaExpanded(true);
+  };
+
+  const uploadFileOrBlob = async (fileOrBlob: File | Blob, type: 'image' | 'video') => {
+    const ext = fileOrBlob instanceof File ? fileOrBlob.name.split('.').pop() : 'jpg';
+    const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${ext}`;
+    const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
+
+    const { error: uploadError } = await supabase.storage.from('media').upload(filePath, fileOrBlob);
+    if (uploadError) {
+      toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
+      return;
+    }
+
+    const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
+    setMediaFiles(prev => [...prev, { url: publicUrl, type }]);
     setMediaExpanded(true);
   };
 
@@ -43,41 +62,45 @@ export default function AsciiNewPostForm({ onAdd, onClose }: { onAdd: (p: NewPos
 
     if (mediaFiles.length + files.length > 4) {
       toast({ title: "Limit reached", description: "Max 4 files", variant: "destructive" });
+      if (fileInputRef.current) fileInputRef.current.value = '';
       return;
     }
 
+    const fileArray = Array.from(files);
+    const validFiles = fileArray.filter(f => {
+      if (!f.type.startsWith('image/') && !f.type.startsWith('video/')) {
+        toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
+        return false;
+      }
+      return true;
+    });
+
+    // Separate croppable images from videos/GIFs
+    const skipFiles = processFiles(validFiles);
+
+    // Upload videos and GIFs directly
+    if (skipFiles.length > 0) {
+      setUploadingMedia(true);
+      try {
+        for (const file of skipFiles) {
+          await uploadFileOrBlob(file, file.type.startsWith('video/') ? 'video' : 'image');
+        }
+      } finally {
+        setUploadingMedia(false);
+      }
+    }
+
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleCropComplete = async (blob: Blob) => {
     setUploadingMedia(true);
     try {
-      for (const file of Array.from(files)) {
-        const isImage = file.type.startsWith('image/');
-        const isVideo = file.type.startsWith('video/');
-
-        if (!isImage && !isVideo) {
-          toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
-          continue;
-        }
-
-        const fileExt = file.name.split('.').pop();
-        const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${fileExt}`;
-        const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
-
-        const { error: uploadError } = await supabase.storage.from('media').upload(filePath, file);
-
-        if (uploadError) {
-          toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
-          continue;
-        }
-
-        const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
-        setMediaFiles(prev => [...prev, { url: publicUrl, type: isImage ? 'image' : 'video' }]);
-        setMediaExpanded(true);
-      }
-    } catch (error) {
-      toast({ title: "Error", description: "Upload failed", variant: "destructive" });
+      await uploadFileOrBlob(blob, 'image');
     } finally {
       setUploadingMedia(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
     }
+    advanceQueue();
   };
 
   const removeMedia = (index: number) => {
@@ -350,6 +373,16 @@ export default function AsciiNewPostForm({ onAdd, onClose }: { onAdd: (p: NewPos
             setMediaExpanded(true);
           }}
           onClose={() => setShowGifPicker(false)}
+        />
+      )}
+
+      {/* Image Cropper Modal */}
+      {isCropping && cropperImage && (
+        <ImageCropperModal
+          image={cropperImage}
+          onCropComplete={handleCropComplete}
+          onCancel={cancelCrop}
+          showAspectRatioSelector
         />
       )}
     </>

--- a/src/components/ImageCropperModal.tsx
+++ b/src/components/ImageCropperModal.tsx
@@ -4,12 +4,20 @@ import type { Area, Point } from 'react-easy-crop';
 import { Button } from '@/components/ui/button';
 import { X, ZoomIn, ZoomOut, RotateCw } from 'lucide-react';
 
+const ASPECT_RATIO_OPTIONS = [
+    { label: 'Free', value: undefined },
+    { label: '1:1', value: 1 },
+    { label: '16:9', value: 16 / 9 },
+    { label: '4:5', value: 4 / 5 },
+] as const;
+
 interface ImageCropperModalProps {
     image: string;
-    aspectRatio: number; // 1 for avatar (square), 4 for header (wide)
+    aspectRatio?: number; // 1 for avatar (square), 4 for header (wide). undefined = free
     onCropComplete: (croppedImageBlob: Blob) => void;
     onCancel: () => void;
     cropShape?: 'rect' | 'round';
+    showAspectRatioSelector?: boolean;
 }
 
 // Utility function to create cropped image
@@ -108,12 +116,16 @@ export default function ImageCropperModal({
     onCropComplete,
     onCancel,
     cropShape = 'rect',
+    showAspectRatioSelector = false,
 }: ImageCropperModalProps) {
     const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
     const [zoom, setZoom] = useState(1);
     const [rotation, setRotation] = useState(0);
     const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
     const [processing, setProcessing] = useState(false);
+    const [selectedAspect, setSelectedAspect] = useState<number | undefined>(aspectRatio);
+
+    const effectiveAspect = showAspectRatioSelector ? selectedAspect : aspectRatio;
 
     const onCropChange = useCallback((location: Point) => {
         setCrop(location);
@@ -162,7 +174,7 @@ export default function ImageCropperModal({
                         crop={crop}
                         zoom={zoom}
                         rotation={rotation}
-                        aspect={aspectRatio}
+                        aspect={effectiveAspect}
                         cropShape={cropShape}
                         onCropChange={onCropChange}
                         onZoomChange={onZoomChange}
@@ -177,6 +189,33 @@ export default function ImageCropperModal({
 
                 {/* Controls */}
                 <div className="p-4 space-y-4 border-t border-green-600/50">
+                    {/* Aspect Ratio Selector */}
+                    {showAspectRatioSelector && (
+                        <div className="flex items-center gap-2">
+                            <span className="text-xs text-green-600 font-mono shrink-0">Ratio:</span>
+                            <div className="flex gap-1.5 flex-1">
+                                {ASPECT_RATIO_OPTIONS.map((opt) => (
+                                    <button
+                                        key={opt.label}
+                                        type="button"
+                                        onClick={() => {
+                                            setSelectedAspect(opt.value);
+                                            setCrop({ x: 0, y: 0 });
+                                            setZoom(1);
+                                        }}
+                                        className={`flex-1 px-2 py-1.5 text-xs font-mono rounded border transition-colors ${
+                                            selectedAspect === opt.value
+                                                ? 'bg-green-600 text-black border-green-500'
+                                                : 'bg-black text-green-500 border-green-900/50 hover:border-green-500/50'
+                                        }`}
+                                    >
+                                        {opt.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
                     {/* Zoom Control */}
                     <div className="flex items-center gap-4">
                         <ZoomOut className="w-4 h-4 text-green-600" />

--- a/src/components/MinimalPostForm.tsx
+++ b/src/components/MinimalPostForm.tsx
@@ -3,9 +3,11 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { useMarkdownPreview } from "@/hooks/useMarkdownPreview";
+import { useImageCropper } from "@/hooks/useImageCropper";
 import { X, Plus, Image, Film, Loader2, Music, Smile, Send, Link2, Mic, Lock, Globe } from "lucide-react";
 import MusicEmbed from "./MusicEmbed";
 import GifPicker from "./GifPicker";
+import ImageCropperModal from "./ImageCropperModal";
 
 export type NewPost = {
     title: string;
@@ -42,6 +44,7 @@ export default function MinimalPostForm({ onAdd, onClose }: MinimalPostFormProps
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const musicInputRef = useRef<HTMLInputElement>(null);
+    const { cropperImage, isCropping, remainingCount, processFiles, advanceQueue, cancelCrop } = useImageCropper();
 
     // Auto-resize textarea
     useEffect(() => {
@@ -65,48 +68,65 @@ export default function MinimalPostForm({ onAdd, onClose }: MinimalPostFormProps
         setShowFab(false);
     };
 
+    const uploadFileOrBlob = async (fileOrBlob: File | Blob, type: 'image' | 'video') => {
+        const ext = fileOrBlob instanceof File ? fileOrBlob.name.split('.').pop() : 'jpg';
+        const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${ext}`;
+        const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
+
+        const { error: uploadError } = await supabase.storage.from('media').upload(filePath, fileOrBlob);
+        if (uploadError) {
+            toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
+            return;
+        }
+
+        const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
+        setMediaFiles(prev => [...prev, { url: publicUrl, type }]);
+    };
+
     const handleMediaUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || files.length === 0) return;
 
         if (mediaFiles.length + files.length > 4) {
             toast({ title: "Limit reached", description: "Max 4 files", variant: "destructive" });
+            if (fileInputRef.current) fileInputRef.current.value = '';
             return;
         }
 
-        setUploadingMedia(true);
         setShowFab(false);
-
-        try {
-            for (const file of Array.from(files)) {
-                const isImage = file.type.startsWith('image/');
-                const isVideo = file.type.startsWith('video/');
-
-                if (!isImage && !isVideo) {
-                    toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
-                    continue;
-                }
-
-                const fileExt = file.name.split('.').pop();
-                const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${fileExt}`;
-                const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
-
-                const { error: uploadError } = await supabase.storage.from('media').upload(filePath, file);
-
-                if (uploadError) {
-                    toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
-                    continue;
-                }
-
-                const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
-                setMediaFiles(prev => [...prev, { url: publicUrl, type: isImage ? 'image' : 'video' }]);
+        const fileArray = Array.from(files);
+        const validFiles = fileArray.filter(f => {
+            if (!f.type.startsWith('image/') && !f.type.startsWith('video/')) {
+                toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
+                return false;
             }
-        } catch (error) {
-            toast({ title: "Error", description: "Upload failed", variant: "destructive" });
+            return true;
+        });
+
+        const skipFiles = processFiles(validFiles);
+
+        if (skipFiles.length > 0) {
+            setUploadingMedia(true);
+            try {
+                for (const file of skipFiles) {
+                    await uploadFileOrBlob(file, file.type.startsWith('video/') ? 'video' : 'image');
+                }
+            } finally {
+                setUploadingMedia(false);
+            }
+        }
+
+        if (fileInputRef.current) fileInputRef.current.value = '';
+    };
+
+    const handleCropComplete = async (blob: Blob) => {
+        setUploadingMedia(true);
+        try {
+            await uploadFileOrBlob(blob, 'image');
         } finally {
             setUploadingMedia(false);
-            if (fileInputRef.current) fileInputRef.current.value = '';
         }
+        advanceQueue();
     };
 
     const removeMedia = (index: number) => {
@@ -392,6 +412,16 @@ export default function MinimalPostForm({ onAdd, onClose }: MinimalPostFormProps
                         setShowGifPicker(false);
                     }}
                     onClose={() => setShowGifPicker(false)}
+                />
+            )}
+
+            {/* Image Cropper Modal */}
+            {isCropping && cropperImage && (
+                <ImageCropperModal
+                    image={cropperImage}
+                    onCropComplete={handleCropComplete}
+                    onCancel={cancelCrop}
+                    showAspectRatioSelector
                 />
             )}
         </>

--- a/src/components/chat/MediaComposer.tsx
+++ b/src/components/chat/MediaComposer.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { X, Image, Film, Smile, Mic, Loader2, Search, Play, Pause, Send, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useImageCropper } from "@/hooks/useImageCropper";
+import ImageCropperModal from "@/components/ImageCropperModal";
 
 interface MediaComposerProps {
     onClose: () => void;
@@ -21,6 +23,22 @@ export default function MediaComposer({
 }: MediaComposerProps) {
     const [activeTab, setActiveTab] = useState<Tab>('media');
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const { cropperImage, isCropping, processFiles, advanceQueue, cancelCrop } = useImageCropper();
+
+    const handleMediaSelectWithCrop = (file: File) => {
+        const isStaticImage = file.type.startsWith('image/') && file.type !== 'image/gif';
+        if (isStaticImage) {
+            processFiles([file]);
+        } else {
+            onMediaSelect(file);
+        }
+    };
+
+    const handleCropComplete = (blob: Blob) => {
+        const croppedFile = new File([blob], `cropped-${Date.now()}.jpg`, { type: 'image/jpeg' });
+        onMediaSelect(croppedFile);
+        advanceQueue();
+    };
 
     return (
         <>
@@ -80,7 +98,7 @@ export default function MediaComposer({
                     {activeTab === 'media' && (
                         <MediaUploader
                             fileInputRef={fileInputRef}
-                            onSelect={onMediaSelect}
+                            onSelect={handleMediaSelectWithCrop}
                         />
                     )}
                     {activeTab === 'gif' && (
@@ -94,6 +112,16 @@ export default function MediaComposer({
                     )}
                 </div>
             </div>
+
+            {/* Image Cropper Modal */}
+            {isCropping && cropperImage && (
+                <ImageCropperModal
+                    image={cropperImage}
+                    onCropComplete={handleCropComplete}
+                    onCancel={cancelCrop}
+                    showAspectRatioSelector
+                />
+            )}
         </>
     );
 }

--- a/src/hooks/useImageCropper.ts
+++ b/src/hooks/useImageCropper.ts
@@ -1,0 +1,71 @@
+import { useState, useCallback, useRef } from 'react';
+
+/**
+ * Hook to manage image cropping queue.
+ * Separates files into croppable (static images) and non-croppable (videos, GIFs).
+ * Shows cropper for each croppable image one by one.
+ */
+export function useImageCropper() {
+    const [cropperImage, setCropperImage] = useState<string | null>(null);
+    const queueRef = useRef<File[]>([]);
+    const [remainingCount, setRemainingCount] = useState(0);
+
+    /**
+     * Separate files into croppable and non-croppable.
+     * Opens the cropper for the first croppable image.
+     * Returns the files that should skip cropping (videos, GIFs).
+     */
+    const processFiles = useCallback((files: File[]): File[] => {
+        const skipFiles: File[] = [];
+        const cropFiles: File[] = [];
+
+        for (const file of files) {
+            const isStaticImage = file.type.startsWith('image/') && file.type !== 'image/gif';
+            if (isStaticImage) {
+                cropFiles.push(file);
+            } else {
+                skipFiles.push(file);
+            }
+        }
+
+        if (cropFiles.length > 0) {
+            const [first, ...rest] = cropFiles;
+            queueRef.current = rest;
+            setRemainingCount(rest.length);
+            setCropperImage(URL.createObjectURL(first));
+        }
+
+        return skipFiles;
+    }, []);
+
+    /** Advance to next file in queue or close cropper */
+    const advanceQueue = useCallback(() => {
+        if (cropperImage) URL.revokeObjectURL(cropperImage);
+
+        if (queueRef.current.length > 0) {
+            const next = queueRef.current.shift()!;
+            setRemainingCount(queueRef.current.length);
+            setCropperImage(URL.createObjectURL(next));
+        } else {
+            setCropperImage(null);
+            setRemainingCount(0);
+        }
+    }, [cropperImage]);
+
+    /** Cancel cropping and clear queue */
+    const cancelCrop = useCallback(() => {
+        if (cropperImage) URL.revokeObjectURL(cropperImage);
+        queueRef.current = [];
+        setCropperImage(null);
+        setRemainingCount(0);
+    }, [cropperImage]);
+
+    return {
+        cropperImage,
+        isCropping: !!cropperImage,
+        remainingCount,
+        processFiles,
+        advanceQueue,
+        cancelCrop,
+    };
+}

--- a/src/pages/CreatePost.tsx
+++ b/src/pages/CreatePost.tsx
@@ -6,9 +6,11 @@ import ThreadCreator from "@/components/thread/ThreadCreator";
 import { createThread } from "@/hooks/useSupabasePosts";
 import { useToast } from "@/hooks/use-toast";
 import { useMarkdownPreview } from "@/hooks/useMarkdownPreview";
+import { useImageCropper } from "@/hooks/useImageCropper";
 import { X, Plus, Image, Film, Loader2, Link2, Music, Smile, ArrowLeft, Save, Send, AlignLeft, AlignCenter, AlignRight, Lock, Globe } from "lucide-react";
 import GifPicker from "@/components/GifPicker";
 import MusicEmbed from "@/components/MusicEmbed";
+import ImageCropperModal from "@/components/ImageCropperModal";
 import { useIdentity, useContentAuthor } from "@/hooks/useIdentity";
 import { useBehaviorTracking } from "@/hooks/useBehaviorTracking";
 import EmailGateModal from "@/components/EmailGateModal";
@@ -352,6 +354,7 @@ export default function CreatePost() {
     const [selectedGif, setSelectedGif] = useState<string | null>(null);
     const [mediaExpanded, setMediaExpanded] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const { cropperImage, isCropping, remainingCount, processFiles, advanceQueue, cancelCrop } = useImageCropper();
 
     // Identity
     const { identity, refreshIdentity } = useIdentity();
@@ -416,46 +419,64 @@ export default function CreatePost() {
         handleSave(false);
     };
 
+    const uploadFileOrBlob = async (fileOrBlob: File | Blob, type: 'image' | 'video') => {
+        const ext = fileOrBlob instanceof File ? fileOrBlob.name.split('.').pop() : 'jpg';
+        const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${ext}`;
+        const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
+
+        const { error: uploadError } = await supabase.storage.from('media').upload(filePath, fileOrBlob);
+        if (uploadError) {
+            toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
+            return;
+        }
+
+        const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
+        setMediaFiles(prev => [...prev, { url: publicUrl, type, file: fileOrBlob instanceof File ? fileOrBlob : undefined }]);
+    };
+
     const handleMediaUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || files.length === 0) return;
 
         if (mediaFiles.length + files.length > 4) {
             toast({ title: "Limit reached", description: "Max 4 files", variant: "destructive" });
+            if (fileInputRef.current) fileInputRef.current.value = '';
             return;
         }
 
+        const fileArray = Array.from(files);
+        const validFiles = fileArray.filter(f => {
+            if (!f.type.startsWith('image/') && !f.type.startsWith('video/')) {
+                toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
+                return false;
+            }
+            return true;
+        });
+
+        const skipFiles = processFiles(validFiles);
+
+        if (skipFiles.length > 0) {
+            setUploadingMedia(true);
+            try {
+                for (const file of skipFiles) {
+                    await uploadFileOrBlob(file, file.type.startsWith('video/') ? 'video' : 'image');
+                }
+            } finally {
+                setUploadingMedia(false);
+            }
+        }
+
+        if (fileInputRef.current) fileInputRef.current.value = '';
+    };
+
+    const handleCropComplete = async (blob: Blob) => {
         setUploadingMedia(true);
         try {
-            for (const file of Array.from(files)) {
-                const isImage = file.type.startsWith('image/');
-                const isVideo = file.type.startsWith('video/');
-
-                if (!isImage && !isVideo) {
-                    toast({ title: "Invalid type", description: "Images/videos only", variant: "destructive" });
-                    continue;
-                }
-
-                const fileExt = file.name.split('.').pop();
-                const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${fileExt}`;
-                const filePath = `post-media/${user?.id || 'anonymous'}/${fileName}`;
-
-                const { error: uploadError } = await supabase.storage.from('media').upload(filePath, file);
-
-                if (uploadError) {
-                    toast({ title: "Upload failed", description: uploadError.message, variant: "destructive" });
-                    continue;
-                }
-
-                const { data: { publicUrl } } = supabase.storage.from('media').getPublicUrl(filePath);
-                setMediaFiles(prev => [...prev, { url: publicUrl, type: isImage ? 'image' : 'video', file }]);
-            }
-        } catch (error) {
-            toast({ title: "Error", description: "Upload failed", variant: "destructive" });
+            await uploadFileOrBlob(blob, 'image');
         } finally {
             setUploadingMedia(false);
-            if (fileInputRef.current) fileInputRef.current.value = '';
         }
+        advanceQueue();
     };
 
     const removeMedia = (index: number) => {
@@ -721,6 +742,16 @@ export default function CreatePost() {
                         setShowGifPicker(false);
                     }}
                     onClose={() => setShowGifPicker(false)}
+                />
+            )}
+
+            {/* Image Cropper Modal */}
+            {isCropping && cropperImage && (
+                <ImageCropperModal
+                    image={cropperImage}
+                    onCropComplete={handleCropComplete}
+                    onCancel={cancelCrop}
+                    showAspectRatioSelector
                 />
             )}
         </>


### PR DESCRIPTION
- Add useImageCropper hook for managing crop queue (skips GIFs/videos)
- Add aspect ratio selector to ImageCropperModal (Free, 1:1, 16:9, 4:5)
- Integrate cropper into AsciiNewPostForm, MinimalPostForm, CreatePost, and MediaComposer
- User picks image → crop modal opens → then uploads cropped blob to Supabase