### PR TITLE
fix(posts,search): stop NULL boolean flags from hiding posts

### DIFF
--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -163,9 +163,12 @@ export async function listPostsFromDb(options?: ListPostsOptions): Promise<ListP
     query = query.or("thread_position.is.null,thread_position.eq.1");
   }
 
-  // If NOT authenticated, only show public posts
+  // If NOT authenticated, only show public posts.
+  // Use `.not(col, 'is', true)` (col IS NOT TRUE) rather than `.eq(false)` so
+  // posts where is_registered_only is NULL (older rows / rows created before the
+  // column existed) are still shown to logged-out visitors instead of vanishing.
   if (!isAuthenticated) {
-    query = query.eq("is_registered_only", false);
+    query = query.not("is_registered_only", "is", true);
   }
 
   query = query.limit(limit + 1); // Fetch one extra to check if more exist

--- a/supabase/fix-posts-visibility-rls.sql
+++ b/supabase/fix-posts-visibility-rls.sql
@@ -1,0 +1,52 @@
+-- Consolidate posts SELECT visibility into ONE authoritative policy.
+--
+-- Why: Multiple migrations each created their own permissive SELECT policy
+-- ("Posts are readable by anyone" in add-soft-delete-to-posts.sql,
+--  "Selective post visibility" in add-registered-only-toggle.sql, etc.).
+-- Postgres OR-combines permissive policies for the same command, so:
+--   * rows were leaking (a deleted post stayed visible because a *different*
+--     policy's clause was satisfied), and
+--   * the "= false" clauses silently dropped rows where the flag was NULL.
+--
+-- Rule we want: a post is visible if it is NOT deleted, NOT removed (hidden),
+-- and NOT a draft -- with registered-only posts gated to logged-in users.
+-- Authors always see their own posts; admins/ceo see everything.
+--
+-- Run this in the Supabase SQL editor. Safe to re-run (idempotent).
+
+-- Drop every known older SELECT policy so only the consolidated one remains.
+drop policy if exists "Posts are readable by anyone"        on public.posts;
+drop policy if exists "Selective post visibility"           on public.posts;
+drop policy if exists "Public posts are viewable by everyone" on public.posts;
+drop policy if exists "posts_select_public"                 on public.posts;
+drop policy if exists "posts_select_own_drafts"             on public.posts;
+
+create policy "posts_select_public"
+  on public.posts
+  for select
+  using (
+    -- Author sees their own posts (including drafts / soft-deleted).
+    (auth.uid() = user_id)
+    -- Admins / CEO see everything.
+    or exists (
+      select 1 from public.profiles pr
+      where pr.id = auth.uid() and pr.role in ('admin', 'ceo')
+    )
+    -- Everyone else: visible unless deleted, removed, or draft.
+    -- coalesce(..., false) keeps NULL-flag rows visible.
+    or (
+      coalesce(is_deleted, false) = false
+      and coalesce(hidden, false) = false
+      and coalesce(draft, false) = false
+      and (
+        coalesce(is_registered_only, false) = false
+        or auth.role() = 'authenticated'
+      )
+    )
+  );
+
+-- Sanity check after running (should return every public, non-deleted post):
+-- select count(*) from public.posts
+-- where coalesce(is_deleted,false)=false
+--   and coalesce(hidden,false)=false
+--   and coalesce(draft,false)=false;

--- a/supabase/search-functions.sql
+++ b/supabase/search-functions.sql
@@ -1,9 +1,16 @@
 -- Add full-text search support to posts
 create extension if not exists pg_trgm;
 
--- Add search index
-create index if not exists idx_posts_search on public.posts 
-using gin(to_tsvector('english', title || ' ' || coalesce(content, '')));
+-- Full-text index. Use the 'simple' config (no English stemming/stop-words) so
+-- non-English content — e.g. Arabic posts — is tokenized verbatim and stays
+-- searchable. coalesce(title) guards against a NULL title nulling the whole vector.
+drop index if exists idx_posts_search;
+create index if not exists idx_posts_search on public.posts
+using gin(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(content, '')));
+
+-- Trigram indexes power the ILIKE substring fallback below (partial-word matches).
+create index if not exists idx_posts_title_trgm on public.posts using gin (title gin_trgm_ops);
+create index if not exists idx_posts_content_trgm on public.posts using gin (content gin_trgm_ops);
 
 -- Full-text search function
 create or replace function search_posts(search_query text)
@@ -17,21 +24,31 @@ returns table (
 ) as $$
 begin
   return query
-  select 
+  select
     p.id,
     p.title,
     p.content,
     p.author_name,
     p.created_at,
     ts_rank(
-      to_tsvector('english', p.title || ' ' || coalesce(p.content, '')),
-      plainto_tsquery('english', search_query)
+      to_tsvector('simple', coalesce(p.title, '') || ' ' || coalesce(p.content, '')),
+      plainto_tsquery('simple', search_query)
     ) as rank
   from public.posts p
-  where 
-    p.draft = false
-    and to_tsvector('english', p.title || ' ' || coalesce(p.content, ''))
-    @@ plainto_tsquery('english', search_query)
+  where
+    -- Use IS NOT TRUE (not "= false") so rows with NULL flags are still returned.
+    -- Respect the "everything except deleted/removed" rule.
+    p.draft is not true
+    and p.hidden is not true
+    and p.is_deleted is not true
+    and (
+      -- Ranked full-text match...
+      to_tsvector('simple', coalesce(p.title, '') || ' ' || coalesce(p.content, ''))
+        @@ plainto_tsquery('simple', search_query)
+      -- ...plus a forgiving substring fallback for partial words / mixed scripts.
+      or p.title ilike '%' || search_query || '%'
+      or p.content ilike '%' || search_query || '%'
+    )
   order by rank desc, p.created_at desc;
 end;
 $$ language plpgsql security definer;


### PR DESCRIPTION
Boolean visibility filters written as `= false` silently drop rows where the column is NULL (older posts predate the columns), causing search to return nothing and posts to go missing from /posts.

- search_posts RPC: use IS NOT TRUE for draft, exclude hidden/is_deleted, switch to the `simple` text config for Arabic content, add an ILIKE trigram fallback for partial-word matches.
- listPostsFromDb: logged-out branch uses `.not(is_registered_only,is,true)` instead of `.eq(false)` so NULL-flag posts stay visible to visitors.
- Add consolidated posts SELECT RLS policy to replace the competing OR-combined policies whose `= false` clauses dropped NULL rows.